### PR TITLE
feat: Get ci config path from gitlab api.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.venv
+.vscode

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # pre-commit-gitlabci-lint
 
-This is a [pre-commit hook](https://pre-commit.com/). Uses the `https://gitlab.com/api/v4/ci/lint` lint endpoint to validate the contents of your `.gitlab-ci.yml` file, but this can be overridden, see below.
+This is a [pre-commit hook](https://pre-commit.com/). It uses the `https://gitlab.com/api/v4/ci/lint` lint endpoint to validate the contents of your `.gitlab-ci.yml` file, but the api v4 url can be adjusted (see below for an example).
 
 ## Usage
 
 GitLab Lint API [requires authorization](https://gitlab.com/gitlab-org/gitlab/-/issues/321290).
+
 1. [Create Access Token](https://gitlab.com/-/profile/personal_access_tokens) with `api` scope.
-2. Set access token value as `GITLAB_TOKEN` environment variable
+2.1 Set access token value as `GITLAB_TOKEN` environment variable
+2.2 Or provide the access token via argument (see example below)
 
 **Warning** Please note the token should not be shared and if leaked can cause significant harm.
 
@@ -22,6 +24,7 @@ repos:
     rev: 1.0
     hooks:
       - id: gitlabci-lint
-      # args: ["https://custom.gitlab.host.com/api/v4/projects/:id/ci/lint"] # for gitlab version > 15.7
-      # args: ["https://custom.gitlab.host.com/api/v4/ci/lint"] # for gitlab version < 15.7
+      # args: ["https://custom.gitlab.host.com/api/v4/projects/:id"] # for gitlab version > 15.7
+      # args: ["https://custom.gitlab.host.com/api/v4"] # for gitlab version < 15.7
+      # args: [--token, 'Your_Gitlab_Access_Token_Value']
 ```

--- a/gitlabci_lint/__init__.py
+++ b/gitlabci_lint/__init__.py
@@ -8,9 +8,10 @@ from urllib.request import Request, urlopen
 
 
 token_env_key = "GITLAB_TOKEN"
+default_ci_config_path = ".gitlab-ci.yml"
 
 parser = argparse.ArgumentParser()
-parser.add_argument("url", nargs="?", default="https://gitlab.com/api/v4/ci/lint")
+parser.add_argument("url", nargs="?", default="https://gitlab.com/api/v4")
 parser.add_argument(
     "--token",
     default=os.getenv(token_env_key),
@@ -30,70 +31,87 @@ def print_messages(messages: List[str]):
     print("=======")
 
 
+def urlerr(err, token):
+    print("Error connecting to Gitlab: " + str(err))
+    if not token and isinstance(err, urllib.error.HTTPError) and err.code == 401:
+        print(
+            "The lint endpoint requires authentication."
+            "Please set {} environment variable".format(token_env_key)
+        )
+
+
 def main(argv=None):
     args = parser.parse_args(argv)
     url = args.url
+    if url.endswith("/"):
+        url = url.rstrip("/")
+    lint_ext = "/ci/lint"
+    if url.endswith(lint_ext):
+        url = url.rstrip(lint_ext)
     token = args.token
+    headers = {
+        "Content-Type": "application/json",
+    }
+    if token:
+        headers["PRIVATE-TOKEN"] = token
 
     rv = 0
     try:
-        with open(".gitlab-ci.yml", "r") as f:
+        response = urlopen(Request(url, headers=headers))
+        project_info = json.loads(response.read())
+        if "ci_config_path" in project_info and project_info["ci_config_path"]:
+            ci_config_path = project_info["ci_config_path"]
+        else:
+            # Use the default path for the gitlab-ci.yml file
+            ci_config_path = default_ci_config_path
+    except urllib.error.URLError:
+        ci_config_path = default_ci_config_path
+
+    try:
+        with open(ci_config_path, "r") as f:
             data = json.dumps({"content": f.read()})
     except (FileNotFoundError, PermissionError):
-        print("Cannot open .gitlab-ci.yml")
-        rv = 1
-    else:
-        # url = urljoin(base_url, "/api/v4/ci/lint")
-        msg_using_linter = "Using linter: " + url
-        headers = {
-            "Content-Type": "application/json",
-            "Content-Length": len(data),
-        }
-        if token:
-            headers["PRIVATE-TOKEN"] = token
-            msg_using_linter += " with token " + len(token) * "*"
-        print(msg_using_linter)
-        try:
-            request = Request(
-                url,
-                data.encode("utf-8"),
-                headers=headers,
-            )
-            response = urlopen(request)
-            lint_output = json.loads(response.read())
+        print(f"Cannot open {ci_config_path}")
+        return 11
 
-            if "status" in lint_output:
-                # Gitlab version < 15.7
-                if not lint_output["status"] == "valid":
-                    print_messages(lint_output["errors"])
-                    rv = 1
-                elif lint_output["warnings"]:
-                    print_messages(lint_output["warnings"])
-            elif "valid" in lint_output:
-                # Gitlab version > 15.7
-                if not lint_output["valid"]:
-                    print_messages(lint_output["errors"])
-                    rv = 1
-                elif lint_output["warnings"]:
-                    print_messages(lint_output["warnings"])
-            else:
-                # Gitlab changed its output again?
-                print(
-                    "Unknown gitlab response. Did gitlab update the ci linter response again?"
-                )
+    url += lint_ext
+    headers["Content-Length"] = len(data)
+    msg_using_linter = "Using linter: " + url
+    if token:
+        msg_using_linter += " with token " + len(token) * "*"
+    print(msg_using_linter)
+    try:
+        request = Request(
+            url,
+            data.encode("utf-8"),
+            headers=headers,
+        )
+        response = urlopen(request)
+        lint_output = json.loads(response.read())
+
+        if "status" in lint_output:
+            # Gitlab version < 15.7
+            if not lint_output["status"] == "valid":
+                print_messages(lint_output["errors"])
                 rv = 1
-        except urllib.error.URLError as exc:
-            print("Error connecting to Gitlab: " + str(exc))
-            if (
-                not token
-                and isinstance(exc, urllib.error.HTTPError)
-                and exc.code == 401
-            ):
-                print(
-                    "The lint endpoint requires authentication."
-                    "Please set {} environment variable".format(token_env_key)
-                )
-            rv = 1
+            elif lint_output["warnings"]:
+                print_messages(lint_output["warnings"])
+        elif "valid" in lint_output:
+            # Gitlab version > 15.7
+            if not lint_output["valid"]:
+                print_messages(lint_output["errors"])
+                rv = 2
+            elif lint_output["warnings"]:
+                print_messages(lint_output["warnings"])
+        else:
+            # Gitlab changed its output again?
+            print(
+                "Unknown gitlab response. Did gitlab update the ci linter response again?"
+            )
+            rv = 3
+    except urllib.error.URLError as err:
+        urlerr(err, token)
+        return 12
     return rv
 
 


### PR DESCRIPTION
Usually, the default ci config path is used (.\gitlab-ci.yml). However, you can specify your own config path within your gitlab project settings. This pull request will read the ci config path from the api before it proceeds calling the linter on that path.